### PR TITLE
Fix Spawner Render

### DIFF
--- a/src/main/java/com/BrassAmber/ba_bt/BrassAmberBattleTowers.java
+++ b/src/main/java/com/BrassAmber/ba_bt/BrassAmberBattleTowers.java
@@ -50,6 +50,8 @@ import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
 import net.minecraftforge.fml.event.lifecycle.InterModProcessEvent;
 import net.minecraftforge.fml.event.server.FMLServerStartingEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.RenderTypeLookup;
 
 // The value here should match an entry in the META-INF/mods.toml file
 @Mod(BrassAmberBattleTowers.MOD_ID)
@@ -198,6 +200,9 @@ public class BrassAmberBattleTowers {
 	// Do something that can only be done on the client
 	private void doClientStuff(final FMLClientSetupEvent event) {
 		// Register Entity Renderers
+		//Render Type Spawner
+		RenderTypeLookup.setRenderLayer(BTBlocks.BT_SPAWNER, RenderType.cutout());
+
 		BTEntityRender.init();
 		// Register TileEntity Renderers
 		BTTileEntityRenderInit.bindTileEntityRenderers(event);


### PR DESCRIPTION
I noticed while playing the mod that the spawner had a small rendering problem unlike the vanilla spawner.
Pictures :

![2021-12-28_10 57 43](https://user-images.githubusercontent.com/83614614/147557458-9239c450-d5cf-4221-81c9-bff75723f6a7.png)

With the RenderType implemented in the client the problem should be fixed (if there is an error add a `.get()`)