### PR TITLE
Fix Spawner Render Bug (V2) !

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'org.spongepowered.mixin'
 apply plugin: 'eclipse'
 
 
-version = "${minecraftVersion}-1.1.2"
+version = "${minecraftVersion}-1.1.3"
 group = 'com.brassAmber.ba_bt' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'BrassAmberBattleTowers'
 

--- a/src/main/java/com/BrassAmber/ba_bt/block/BTBlocks.java
+++ b/src/main/java/com/BrassAmber/ba_bt/block/BTBlocks.java
@@ -50,7 +50,7 @@ public class BTBlocks {
 
 	public static final Block TAB_ICON = registerBlockNoGroup("tab_icon", new TabIconBlock(AbstractBlock.Properties.of(Material.STONE).strength(-1.0F, 3600000.0F).sound(SoundType.STONE)));
 
-    public static final Block BT_SPAWNER = registerSpawnerBlock("bt_spawner", new BTSpawner(AbstractBlock.Properties.of(Material.STONE).requiresCorrectToolForDrops().strength(5.0F).sound(SoundType.METAL)));
+    public static final Block BT_SPAWNER = registerSpawnerBlock("bt_spawner", new BTSpawner(AbstractBlock.Properties.of(Material.STONE).requiresCorrectToolForDrops().strength(5.0F).sound(SoundType.METAL).noOcclusion()));
 
 	@OnlyIn(Dist.CLIENT)
 	@SubscribeEvent()


### PR DESCRIPTION
The spawner block allows you to see through the floors of the tower and also the floor of the world.
To fix it I added a `.noOcclusion()` to the block declaration.