### PR TITLE
Explosion sound volume reduction and general timing/amount cleanup. Spawn golem sound subtitle fixed

### DIFF
--- a/src/main/java/com/BrassAmber/ba_bt/entity/DestroyTowerEntity.java
+++ b/src/main/java/com/BrassAmber/ba_bt/entity/DestroyTowerEntity.java
@@ -193,13 +193,14 @@ public class DestroyTowerEntity extends Entity {
                             this.level.setBlock(this.removeBlock, Blocks.AIR.defaultBlockState(), BlockFlags.DEFAULT);
 
                         }
-                        if (i == 20) {
-                    		this.level.levelEvent(Constants.WorldEvents.SPAWN_EXPLOSION_PARTICLE, this.removeBlock, 0);
-                            this.level.playSound(null, this.removeBlock,
-                                    SoundEvents.GENERIC_EXPLODE, SoundCategory.BLOCKS,3.0F,
-                                    1.0F);
-                        }
 
+
+                    }
+                    if (this.currentTicks % 6 == 0) {
+                        this.level.levelEvent(Constants.WorldEvents.SPAWN_EXPLOSION_PARTICLE, this.removeBlock, 0);
+                        this.level.playSound(null, this.removeBlock,
+                                SoundEvents.GENERIC_EXPLODE, SoundCategory.BLOCKS,2.0F,
+                                1.0F);
                     }
 
                 }

--- a/src/main/java/com/BrassAmber/ba_bt/entity/ExplosionPhysicsEntity.java
+++ b/src/main/java/com/BrassAmber/ba_bt/entity/ExplosionPhysicsEntity.java
@@ -87,7 +87,7 @@ public class ExplosionPhysicsEntity extends TNTEntity {
 	}
 	
 	protected Explosion explosion() {
-		Explosion explosion = new Explosion(this.level, null, null, null, this.getX(), this.getY(0.0625D), this.getZ(), 4.0F, false, Explosion.Mode.BREAK);
+		Explosion explosion = new Explosion(this.level, null, null, null, this.getX(), this.getY(0.0625D), this.getZ(), 4.0F, false, Explosion.Mode.DESTROY);
 		return explosion;
 	}
 	

--- a/src/main/java/com/BrassAmber/ba_bt/entity/ExplosionPhysicsEntity.java
+++ b/src/main/java/com/BrassAmber/ba_bt/entity/ExplosionPhysicsEntity.java
@@ -7,10 +7,13 @@ import net.minecraft.block.BlockState;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.item.FallingBlockEntity;
 import net.minecraft.entity.item.TNTEntity;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.util.SoundEvents;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.vector.Vector3d;
 import net.minecraft.world.Explosion;
 import net.minecraft.world.World;
+import net.minecraftforge.common.util.Constants;
 
 public class ExplosionPhysicsEntity extends TNTEntity {
 
@@ -60,6 +63,10 @@ public class ExplosionPhysicsEntity extends TNTEntity {
 					fallingBlock.setDeltaMovement(velocity);
 					
 					physicObjects.add(fallingBlock);
+
+					this.level.levelEvent(Constants.WorldEvents.SPAWN_EXPLOSION_PARTICLE, pos, 0);
+					this.level.playSound(null, pos, SoundEvents.GENERIC_EXPLODE, SoundCategory.BLOCKS,
+							2.0F, 1.0F);
 				}
 			}
 			expl.clearToBlow();

--- a/src/main/resources/assets/ba_bt/lang/en_us.json
+++ b/src/main/resources/assets/ba_bt/lang/en_us.json
@@ -29,6 +29,8 @@
 	"ba_bt.subtitle.golem.awaken": "Golem awakens",
 	"ba_bt.subtitle.golem.ambient": "Golem growls",
 	"ba_bt.subtitle.golem.special": "Golem attacks",
+
+	"ba_bt.subtitle.monolith.spawn.golem": "Golem Begins Spawning",
 	
 	"ba_bt.subtitle.tower.break.start": "Tower starts breaking",
 	"ba_bt.subtitle.tower.break.crumble": "Tower crumbles down",


### PR DESCRIPTION
Explosion mode Break -> Destroy to clean up extra block items that get dropped. 

Will be a part of the version that has spawner occlusion fixed.