### PR TITLE
Server Crash fix and Tower Spawn distance increase.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'org.spongepowered.mixin'
 apply plugin: 'eclipse'
 
 
-version = "${minecraftVersion}-1.1.3"
+version = "${minecraftVersion}-1.1.4"
 group = 'com.brassAmber.ba_bt' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'BrassAmberBattleTowers'
 

--- a/src/main/java/com/BrassAmber/ba_bt/BTConfiguredStructures.java
+++ b/src/main/java/com/BrassAmber/ba_bt/BTConfiguredStructures.java
@@ -10,12 +10,12 @@ import net.minecraft.world.gen.FlatGenerationSettings;
 public class BTConfiguredStructures {
 
     public static StructureFeature<?, ?> CONFIGURED_LAND_BATTLE_TOWER = BTStructures.LAND_BATTLE_TOWER.get().configured(IFeatureConfig.NONE);
-    public static StructureFeature<?, ?> CONFIGURED_SKY_BATTLE_TOWER = BTStructures.SKY_BATTLE_TOWER.get().configured(IFeatureConfig.NONE);
+    public static StructureFeature<?, ?> CONFIGURED_SKY_BATTLE_TOWER = BTStructures
+            .SKY_BATTLE_TOWER.get().configured(IFeatureConfig.NONE);
 
     public static void registerConfiguredStructures() {
         Registry<StructureFeature<?, ?>> registry = WorldGenRegistries.CONFIGURED_STRUCTURE_FEATURE;
         Registry.register(registry, new ResourceLocation(BrassAmberBattleTowers.MOD_ID, "bottom_floor_1"), CONFIGURED_LAND_BATTLE_TOWER);
-        Registry.register(registry, new ResourceLocation(BrassAmberBattleTowers.MOD_ID, "sky_base"), CONFIGURED_SKY_BATTLE_TOWER);
 
         /* Ok so, this part may be hard to grasp but basically, just add your structure to this to
          * prevent any sort of crash or issue with other mod's custom ChunkGenerators. If they use

--- a/src/main/java/com/BrassAmber/ba_bt/BTStructures.java
+++ b/src/main/java/com/BrassAmber/ba_bt/BTStructures.java
@@ -21,6 +21,7 @@ public class BTStructures {
     public static final DeferredRegister<Structure<?>> DEFERRED_REGISTRY_STRUCTURE = DeferredRegister.create(ForgeRegistries.STRUCTURE_FEATURES, BrassAmberBattleTowers.MOD_ID);
 
     public static final RegistryObject<Structure<NoFeatureConfig>> LAND_BATTLE_TOWER = DEFERRED_REGISTRY_STRUCTURE.register("land_battle_tower", () -> (new LandBattleTower(NoFeatureConfig.CODEC)));
+    public static final RegistryObject<Structure<NoFeatureConfig>> SKY_BATTLE_TOWER = DEFERRED_REGISTRY_STRUCTURE.register("sky_battle_tower", () -> (new SkyBattleTower(NoFeatureConfig.CODEC)));
 
     /**
      * This is where we set the rarity of your structures and determine if land conforms to it.
@@ -33,6 +34,13 @@ public class BTStructures {
                         16 /* minimum distance apart in chunks between spawn attempts. MUST BE LESS THAN ABOVE VALUE*/,
                         1234567890 /* this modifies the seed of the structure so no two structures always spawn over each-other. Make this large and unique. */),
                 false);
+        setupMapSpacingAndLand(
+                SKY_BATTLE_TOWER.get(), /* The instance of the structure */
+                new StructureSeparationSettings(26 /* average distance apart in chunks between spawn attempts */,
+                        22 /* minimum distance apart in chunks between spawn attempts. MUST BE LESS THAN ABOVE VALUE*/,
+                        1526374890 /* this modifies the seed of the structure so no two structures always spawn over each-other. Make this large and unique. */),
+                false);
+
 
         // Add more structures here and so on
     }

--- a/src/main/java/com/BrassAmber/ba_bt/BTStructures.java
+++ b/src/main/java/com/BrassAmber/ba_bt/BTStructures.java
@@ -21,7 +21,6 @@ public class BTStructures {
     public static final DeferredRegister<Structure<?>> DEFERRED_REGISTRY_STRUCTURE = DeferredRegister.create(ForgeRegistries.STRUCTURE_FEATURES, BrassAmberBattleTowers.MOD_ID);
 
     public static final RegistryObject<Structure<NoFeatureConfig>> LAND_BATTLE_TOWER = DEFERRED_REGISTRY_STRUCTURE.register("land_battle_tower", () -> (new LandBattleTower(NoFeatureConfig.CODEC)));
-    public static final RegistryObject<Structure<NoFeatureConfig>> SKY_BATTLE_TOWER = DEFERRED_REGISTRY_STRUCTURE.register("sky_battle_tower", () -> (new SkyBattleTower(NoFeatureConfig.CODEC)));
 
     /**
      * This is where we set the rarity of your structures and determine if land conforms to it.
@@ -30,17 +29,10 @@ public class BTStructures {
     public static void setupStructures() {
         setupMapSpacingAndLand(
                 LAND_BATTLE_TOWER.get(), /* The instance of the structure */
-                new StructureSeparationSettings(16 /* average distance apart in chunks between spawn attempts */,
-                        12 /* minimum distance apart in chunks between spawn attempts. MUST BE LESS THAN ABOVE VALUE*/,
+                new StructureSeparationSettings(20 /* average distance apart in chunks between spawn attempts */,
+                        16 /* minimum distance apart in chunks between spawn attempts. MUST BE LESS THAN ABOVE VALUE*/,
                         1234567890 /* this modifies the seed of the structure so no two structures always spawn over each-other. Make this large and unique. */),
                 false);
-        setupMapSpacingAndLand(
-                SKY_BATTLE_TOWER.get(), /* The instance of the structure */
-                new StructureSeparationSettings(26 /* average distance apart in chunks between spawn attempts */,
-                        22 /* minimum distance apart in chunks between spawn attempts. MUST BE LESS THAN ABOVE VALUE*/,
-                        1526374890 /* this modifies the seed of the structure so no two structures always spawn over each-other. Make this large and unique. */),
-                false);
-
 
         // Add more structures here and so on
     }

--- a/src/main/java/com/BrassAmber/ba_bt/BrassAmberBattleTowers.java
+++ b/src/main/java/com/BrassAmber/ba_bt/BrassAmberBattleTowers.java
@@ -1,10 +1,15 @@
 package com.BrassAmber.ba_bt;
 
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import net.minecraft.client.Minecraft;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.fml.DistExecutor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -85,8 +90,11 @@ public class BrassAmberBattleTowers {
 		eventBus.addListener(this::enqueueIMC);
 		// Register the processIMC method for modloading
 		eventBus.addListener(this::processIMC);
+
 		// Register the doClientStuff method for modloading
+		// the check for client only is isnide the method.
 		eventBus.addListener(this::doClientStuff);
+
 
 		// Register ourselves for server and other game events we are interested in
 		MinecraftForge.EVENT_BUS.register(this);
@@ -199,13 +207,19 @@ public class BrassAmberBattleTowers {
 
 	// Do something that can only be done on the client
 	private void doClientStuff(final FMLClientSetupEvent event) {
-		// Register Entity Renderers
-		//Render Type Spawner
-		RenderTypeLookup.setRenderLayer(BTBlocks.BT_SPAWNER, RenderType.cutout());
+		try {
+			boolean isClient = event.getMinecraftSupplier().get().level.isClientSide();
+		} catch (Exception e) {
+			e.printStackTrace();
+			// Register Entity Renderers
+			//Render Type Spawner
+			RenderTypeLookup.setRenderLayer(BTBlocks.BT_SPAWNER, RenderType.cutout());
 
-		BTEntityRender.init();
-		// Register TileEntity Renderers
-		BTTileEntityRenderInit.bindTileEntityRenderers(event);
+			BTEntityRender.init();
+			// Register TileEntity Renderers
+			BTTileEntityRenderInit.bindTileEntityRenderers(event);
+		}
+
 	}
 
 	private void enqueueIMC(final InterModEnqueueEvent event) {
@@ -230,16 +244,5 @@ public class BrassAmberBattleTowers {
 
 	public static ResourceLocation locate(String name) {
 		return new ResourceLocation(MOD_ID, name);
-	}
-
-	// You can use EventBusSubscriber to automatically subscribe events on the contained class (this is subscribing to the MOD
-	// Event bus for receiving Registry Events)
-	@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD)
-	public static class RegistryEvents {
-		@SubscribeEvent
-		public static void onBlocksRegistry(final RegistryEvent.Register<Block> blockRegistryEvent) {
-			// register a new block here
-			LOGGER.info("HELLO from Register Block");
-		}
 	}
 }

--- a/src/main/java/com/BrassAmber/ba_bt/block/block/BTSpawner.java
+++ b/src/main/java/com/BrassAmber/ba_bt/block/block/BTSpawner.java
@@ -56,69 +56,70 @@ public class BTSpawner extends ContainerBlock {
         return ItemStack.EMPTY;
     }
 
-    public void checkPos(World world, BlockPos pos) {
+    public void checkPos(IWorld world, BlockPos pos) {
         TileEntity posEntity = world.getBlockEntity(pos);
 
         if (posEntity != null && posEntity.getType() == BTTileEntityTypes.STONE_CHEST) {
             this.chestTileEntityPos = pos;
-
         }
     }
 
     public void destroy(IWorld iWorld, BlockPos spawnerPos, BlockState blockState) {
         this.foundChest = false;
         this.chestTileEntityPos = null;
-        World world = Minecraft.getInstance().getSingleplayerServer().overworld();
-        for (int x = -30; x<31; x++) {
-            if (this.foundChest) {
-                break;
-            }
-            for (int z = -30; z<31; z++) {
+        if (!iWorld.isClientSide()) {
+            for (int x = -30; x<31; x++) {
                 if (this.foundChest) {
                     break;
                 }
-                BlockPos newBlockPos = new BlockPos(spawnerPos.getX() + x, spawnerPos.getY(), spawnerPos.getZ() + z);
-                checkPos(world, newBlockPos);
-                checkPos(world, newBlockPos.below());
-                checkPos(world, newBlockPos.above());
-                if (this.chestTileEntityPos != null) {
-                    this.foundChest = true;
-                }
-            }
-        }
-        if (this.chestTileEntityPos == null) {
-            for (int x = -5; x<6; x++) {
-                if (this.foundChest) {
-                    break;
-                }
-                for (int z = -5; z < 6; z++) {
+                for (int z = -30; z<31; z++) {
                     if (this.foundChest) {
                         break;
                     }
                     BlockPos newBlockPos = new BlockPos(spawnerPos.getX() + x, spawnerPos.getY(), spawnerPos.getZ() + z);
-                    checkPos(world, newBlockPos);
-                    checkPos(world, newBlockPos.below(1));
-                    checkPos(world, newBlockPos.below(2));
-                    checkPos(world, newBlockPos.below(3));
-                    checkPos(world, newBlockPos.below(4));
-                    checkPos(world, newBlockPos.below(5));
-                    checkPos(world, newBlockPos.below(6));
-                    checkPos(world, newBlockPos.below(7));
+                    checkPos(iWorld, newBlockPos);
+                    checkPos(iWorld, newBlockPos.below());
+                    checkPos(iWorld, newBlockPos.above());
                     if (this.chestTileEntityPos != null) {
                         this.foundChest = true;
                     }
                 }
             }
+            if (this.chestTileEntityPos == null) {
+                for (int x = -5; x<6; x++) {
+                    if (this.foundChest) {
+                        break;
+                    }
+                    for (int z = -5; z < 6; z++) {
+                        if (this.foundChest) {
+                            break;
+                        }
+                        BlockPos newBlockPos = new BlockPos(spawnerPos.getX() + x, spawnerPos.getY(), spawnerPos.getZ() + z);
+                        checkPos(iWorld, newBlockPos);
+                        checkPos(iWorld, newBlockPos.below(1));
+                        checkPos(iWorld, newBlockPos.below(2));
+                        checkPos(iWorld, newBlockPos.below(3));
+                        checkPos(iWorld, newBlockPos.below(4));
+                        checkPos(iWorld, newBlockPos.below(5));
+                        checkPos(iWorld, newBlockPos.below(6));
+                        checkPos(iWorld, newBlockPos.below(7));
+                        if (this.chestTileEntityPos != null) {
+                            this.foundChest = true;
+                        }
+                    }
+                }
+            }
+            try {
+                StoneChestTileEntity entity = (StoneChestTileEntity) iWorld.getBlockEntity(this.chestTileEntityPos);
+                BrassAmberBattleTowers.LOGGER.log(Level.DEBUG,"Chest " + entity);
+                entity.spawnerDestroyed();
+
+            } catch (Exception e) {
+
+            }
+
         }
-        try {
-            StoneChestTileEntity entity = (StoneChestTileEntity) world.getBlockEntity(this.chestTileEntityPos);
-            BrassAmberBattleTowers.LOGGER.log(Level.DEBUG,"Chest " + entity);
-            entity.spawnerDestroyed();
-
-        } catch (Exception e) {
-
-        }
-
     }
+
 
 }

--- a/src/main/java/com/BrassAmber/ba_bt/block/tileentity/client/BTChestTextures.java
+++ b/src/main/java/com/BrassAmber/ba_bt/block/tileentity/client/BTChestTextures.java
@@ -4,10 +4,13 @@ import com.BrassAmber.ba_bt.BrassAmberBattleTowers;
 
 import net.minecraft.client.renderer.Atlases;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
+
 
 @EventBusSubscriber(modid = BrassAmberBattleTowers.MOD_ID, bus = Bus.MOD)
 public class BTChestTextures {
@@ -17,7 +20,8 @@ public class BTChestTextures {
 	/**
 	 * We need to stitch the textures before we can use them. Otherwise they'll just appear as missing textures.
 	 */
-	@SubscribeEvent
+	@OnlyIn(Dist.CLIENT)
+	@SubscribeEvent()
 	public static void textureStitch(TextureStitchEvent.Pre event) {
 		if (event.getMap().location().equals(Atlases.CHEST_SHEET)) {
 			stitchAll(event, GOLEM_CHEST_TEXTURES);

--- a/src/main/java/com/BrassAmber/ba_bt/block/tileentity/client/BTTileEntityRenderInit.java
+++ b/src/main/java/com/BrassAmber/ba_bt/block/tileentity/client/BTTileEntityRenderInit.java
@@ -6,11 +6,18 @@ import com.BrassAmber.ba_bt.block.tileentity.client.renderer.GolemChestTileEntit
 import com.BrassAmber.ba_bt.block.tileentity.client.renderer.StoneChestTileEntityRenderer;
 
 import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
+import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 
+@Mod.EventBusSubscriber
 public class BTTileEntityRenderInit {
-	
+
+	@OnlyIn(Dist.CLIENT)
+	@SubscribeEvent
 	public static void bindTileEntityRenderers(final FMLClientSetupEvent event) {
 		ClientRegistry.bindTileEntityRenderer(BTTileEntityTypes.GOLEM_CHEST, GolemChestTileEntityRenderer::new);
 		ClientRegistry.bindTileEntityRenderer(BTTileEntityTypes.STONE_CHEST, StoneChestTileEntityRenderer::new);

--- a/src/main/java/com/BrassAmber/ba_bt/block/tileentity/client/renderer/BTMobSpawnerTileEntityRenderer.java
+++ b/src/main/java/com/BrassAmber/ba_bt/block/tileentity/client/renderer/BTMobSpawnerTileEntityRenderer.java
@@ -12,7 +12,10 @@ import net.minecraft.tileentity.MobSpawnerTileEntity;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.vector.Vector3f;
 import net.minecraft.world.spawner.AbstractSpawner;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 
+@OnlyIn(Dist.CLIENT)
 public class BTMobSpawnerTileEntityRenderer extends TileEntityRenderer<BTMobSpawnerTileEntity> {
     public BTMobSpawnerTileEntityRenderer(TileEntityRendererDispatcher p_i226016_1_) {
         super(p_i226016_1_);

--- a/src/main/java/com/BrassAmber/ba_bt/entity/DestroyTowerEntity.java
+++ b/src/main/java/com/BrassAmber/ba_bt/entity/DestroyTowerEntity.java
@@ -1,15 +1,18 @@
 package com.BrassAmber.ba_bt.entity;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Random;
-import java.util.Set;
+import java.util.*;
 
 import com.BrassAmber.ba_bt.sound.BTSoundEvents;
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityPredicate;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.item.FallingBlockEntity;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.network.play.client.CChatMessagePacket;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.text.ITextComponent;
 import org.apache.logging.log4j.Level;
 
 import com.BrassAmber.ba_bt.BrassAmberBattleTowers;
@@ -119,7 +122,7 @@ public class DestroyTowerEntity extends Entity {
     
     @Override
     public void tick() {
-    	if(this.level.isClientSide) {
+    	if(this.level.isClientSide()) {
     		return;
     	}
         super.tick();
@@ -131,28 +134,37 @@ public class DestroyTowerEntity extends Entity {
                 this.init();
             }
             if (this.currentTicks == 1) {
-                Minecraft.getInstance().player.chat("/gamerule sendCommandFeedback false");
-                Minecraft.getInstance().player.chat("/title @a[distance=0..120] times 30 40 20");
-                Minecraft.getInstance().player.chat("/title @a[distance=0..120] title \"\"");
-                Minecraft.getInstance().player.chat(
-                        "/title @a[distance=0..120] subtitle {\"text\":\"" + this.specs.getCapitalizedName()
-                                + " Guardian Has Fallen\",\"color\":\"" + this.specs.getColorCode() + "\"}");
+
+                for (ServerPlayerEntity player : this.level.getServer().overworld().players()
+                     ) {
+                    player.connection.handleChat(new CChatMessagePacket("/gamerule sendCommandFeedback false"));
+                    player.connection.handleChat(new CChatMessagePacket("/title @a[distance=0..2] times 30 40 20"));
+                    player.connection.handleChat(new CChatMessagePacket("/title @a[distance=0..2] title \"\""));
+                    player.connection.handleChat(new CChatMessagePacket("/title @a[distance=0..2] subtitle {\"text\":\"" + this.specs.getCapitalizedName()
+                            + " Guardian Has Fallen\",\"color\":\"" + this.specs.getColorCode() + "\"}"));
+                }
                 this.level.playSound(null, this.getCrumbleStart().below(6),
                         BTSoundEvents.TOWER_BREAK_START, SoundCategory.AMBIENT, 6.0F, 1F);
             } else if (this.currentTicks == 200) {
-                Minecraft.getInstance().player.chat("/title @a[distance=0..120] title \"\"");
-                Minecraft.getInstance().player.chat(
-                        "/title @a[distance=0..120] subtitle {\"text\":\"Without it's energy... "
-                        + "\",\"color\":\"#aaaaaa\"}");
+                for (ServerPlayerEntity player : this.level.getServer().overworld().players()
+                ) {
+                    player.connection.handleChat(new CChatMessagePacket("/title @a[distance=0..2] title \"\""));
+                    player.connection.handleChat(new CChatMessagePacket("/title @a[distance=0..2] subtitle {\"text\":\"Without it's energy... "
+                            + "\",\"color\":\"#aaaaaa\"}"));
+
+                }
                 this.level.playSound(null, this.getCrumbleStart().below(6),
                         BTSoundEvents.TOWER_BREAK_START, SoundCategory.AMBIENT, 6.0F, 1F);
 
-            } else if (this.currentTicks == 300) {
-                Minecraft.getInstance().player.chat("/title @a[distance=0..120] title \"\"");
-                Minecraft.getInstance().player.chat(
-                        "/title @a[distance=0..120] subtitle {\"text\":\""
-                                + "The tower will collapse...\",\"color\":\"#aa0000\"}");
-            } else if (this.currentTicks == 400) {
+            }  else if (this.currentTicks == 300) {
+                for (ServerPlayerEntity player : this.level.getServer().overworld().players()
+                ) {
+                    player.connection.handleChat(new CChatMessagePacket("/title @p[distance=0..2] title \"\""));
+                    player.connection.handleChat(new CChatMessagePacket("/title @a[distance=0..2] subtitle {\"text\":\""
+                            + "The tower will collapse...\",\"color\":\"#aa0000\"}"));
+                    player.connection.handleChat(new CChatMessagePacket("/gamerule sendCommandFeedback true"));
+                }
+            }else if (this.currentTicks == 400) {
                 this.level.playSound(null, this.getCrumbleStart().below(6),
                         BTSoundEvents.TOWER_BREAK_CRUMBLE, SoundCategory.AMBIENT, 6.0F, 1F);
             }

--- a/src/main/java/com/BrassAmber/ba_bt/entity/ExplosionPhysicsEntity.java
+++ b/src/main/java/com/BrassAmber/ba_bt/entity/ExplosionPhysicsEntity.java
@@ -23,6 +23,9 @@ public class ExplosionPhysicsEntity extends TNTEntity {
 	
 	@Override
 	public void tick() {
+		if(this.level.isClientSide) {
+			return;
+		}
 		if(this.firstTick) {
 			this.firstTick = false;
 			return;

--- a/src/main/java/com/BrassAmber/ba_bt/entity/ai/goal/GolemFireballAttackGoal.java
+++ b/src/main/java/com/BrassAmber/ba_bt/entity/ai/goal/GolemFireballAttackGoal.java
@@ -53,62 +53,64 @@ public class GolemFireballAttackGoal extends Goal {
 	public void tick() {
 		LivingEntity targetLivingEntity = this.golem.getTarget();
 		// Look at the target.
-		this.golem.getLookControl().setLookAt(targetLivingEntity, 30.0F, 30.0F);
+		if (targetLivingEntity != null) {
+			this.golem.getLookControl().setLookAt(targetLivingEntity, 30.0F, 30.0F);
 
-		// Set the max shooting distance
-		double maxShootingDistance = 64.0D;
-		// We need to square it since we're using that value for calculations.
-		maxShootingDistance *= maxShootingDistance;
+			// Set the max shooting distance
+			double maxShootingDistance = 64.0D;
+			// We need to square it since we're using that value for calculations.
+			maxShootingDistance *= maxShootingDistance;
 
-		// Check if the target is within range and if the Golem is able to see the target.
-		if (targetLivingEntity.distanceToSqr(this.golem) < maxShootingDistance && this.golem.canSee(targetLivingEntity)) {
-			// Increase attack time
-			++this.chargeTime;
+			// Check if the target is within range and if the Golem is able to see the target.
+			if (targetLivingEntity.distanceToSqr(this.golem) < maxShootingDistance && this.golem.canSee(targetLivingEntity)) {
+				// Increase attack time
+				++this.chargeTime;
 
-			// Prepare to shoot. (10 more ticks, or 0.5 seconds)
-			if (this.chargeTime == 10 && !this.golem.isSilent()) {
-				// Play charging sound
-				this.golem.playSoundEventWithVariation(BTSoundEvents.ENTITY_GOLEM_CHARGE);
-			}
-
-			// Shoot fireball
-			if (this.chargeTime >= 20) {
-				// Calculation for fireball trajectory and positioning.
-				Vector3d vector3d = this.golem.getViewVector(1.0F);
-				double xPower = targetLivingEntity.getX() - this.golem.getX();
-				double yPower = targetLivingEntity.getY(0.5D) - (0.5D + this.golem.getY(0.5D));
-				double zPower = targetLivingEntity.getZ() - this.golem.getZ();
-
-				// Get golem world
-				World world = this.golem.level;
-
-				// Play shooting sound
-				if (!this.golem.isSilent()) {
-					world.levelEvent((PlayerEntity) null, 1016, this.golem.blockPosition(), 0);
+				// Prepare to shoot. (10 more ticks, or 0.5 seconds)
+				if (this.chargeTime == 10 && !this.golem.isSilent()) {
+					// Play charging sound
+					this.golem.playSoundEventWithVariation(BTSoundEvents.ENTITY_GOLEM_CHARGE);
 				}
 
-				// Create fireball
-				DamagingProjectileEntity fireballentity = this.createFireBall(world, xPower, yPower, zPower);
-				// Set fireball initial position
-				double lateralSpawnPositionOffset = 1.2D;
-				double verticalSpawnPositionOffset = 0.5D;
-				fireballentity.setPos(this.golem.getX() + vector3d.x * lateralSpawnPositionOffset, this.golem.getY(0.5D) + verticalSpawnPositionOffset, fireballentity.getZ() + vector3d.z * lateralSpawnPositionOffset);
-				// Add fireball to the world
-				world.addFreshEntity(fireballentity);
+				// Shoot fireball
+				if (this.chargeTime >= 20) {
+					// Calculation for fireball trajectory and positioning.
+					Vector3d vector3d = this.golem.getViewVector(1.0F);
+					double xPower = targetLivingEntity.getX() - this.golem.getX();
+					double yPower = targetLivingEntity.getY(0.5D) - (0.5D + this.golem.getY(0.5D));
+					double zPower = targetLivingEntity.getZ() - this.golem.getZ();
 
-				// set firing timeout between shoots
-				this.chargeTime = this.golem.isEnraged() ? -20 : -40;
+					// Get golem world
+					World world = this.golem.level;
+
+					// Play shooting sound
+					if (!this.golem.isSilent()) {
+						world.levelEvent((PlayerEntity) null, 1016, this.golem.blockPosition(), 0);
+					}
+
+					// Create fireball
+					DamagingProjectileEntity fireballentity = this.createFireBall(world, xPower, yPower, zPower);
+					// Set fireball initial position
+					double lateralSpawnPositionOffset = 1.2D;
+					double verticalSpawnPositionOffset = 0.5D;
+					fireballentity.setPos(this.golem.getX() + vector3d.x * lateralSpawnPositionOffset, this.golem.getY(0.5D) + verticalSpawnPositionOffset, fireballentity.getZ() + vector3d.z * lateralSpawnPositionOffset);
+					// Add fireball to the world
+					world.addFreshEntity(fireballentity);
+
+					// set firing timeout between shoots
+					this.chargeTime = this.golem.isEnraged() ? -20 : -40;
+				}
 			}
-		}
 
-		// If target is too far away or the golem can't see the target and the current charge time is more than 0.
-		else if (this.chargeTime > 0) {
-			// Decrease charge time until 0. (Which is the default)
-			--this.chargeTime;
-		}
+			// If target is too far away or the golem can't see the target and the current charge time is more than 0.
+			else if (this.chargeTime > 0) {
+				// Decrease charge time until 0. (Which is the default)
+				--this.chargeTime;
+			}
 
-		// 10 ticks before shooting, so while preparing to shoot, set the DataParameter charging to 'true'.
-		this.golem.setCharging(this.chargeTime > 10);
+			// 10 ticks before shooting, so while preparing to shoot, set the DataParameter charging to 'true'.
+			this.golem.setCharging(this.chargeTime > 10);
+		}
 	}
 	
 	protected DamagingProjectileEntity createFireBall(World world, double xPower, double yPower, double zPower) {

--- a/src/main/java/com/BrassAmber/ba_bt/entity/block/MonolithEntity.java
+++ b/src/main/java/com/BrassAmber/ba_bt/entity/block/MonolithEntity.java
@@ -132,8 +132,12 @@ public class MonolithEntity extends Entity {
 
 		// Handles the floating animation
 		++this.floatingRotation;
-		// Animate particles.
-		this.animateTick();
+
+		if (this.level.isClientSide()) {
+			// Animate particles.
+			this.animateTick();
+		}
+
 
 		// Play ambient sounds at random intervals.
 		if (this.isAlive() && this.random.nextInt(1000) < this.livingSoundTime++) {


### PR DESCRIPTION
Version-> 1.1.4 

- removed Sky Tower from configured structure registry.
- upped land tower minimum separation by 4 chunks 

- change code in doClientStuff to try and check for isClientSide(), oddly when on a singleplayer world this code produces an error, which is then caught with a catch statement that then calls the correct code for singleplayer worlds. 

- changed BTSpawner code to use IWorld instead of Minecraft.getInstance().getSingleplayerServer().overworld();, and added a check for if the IWorld is NOT clientSide.

- Added @OnyIn(Dist.Client) to several files 

- Found a way to send chat messages that can have commands in them by using this.level.getServer().overworld().players()
and then calling player.connection.handleChat()

- added isLivingEntity == null check to BTFireballAttackCode in case PlayerDies or becomes untargetable during attackgoal code. (See bug report on BT Curseforge - Hardcore Revival mod non-dead state suspected to be the cause but not confirmed. 

- Added isClientSide check to monolith animation
