### PR TITLE
Updated italian translations as requested

### DIFF
--- a/src/main/resources/assets/ba_bt/lang/it_ch.json
+++ b/src/main/resources/assets/ba_bt/lang/it_ch.json
@@ -3,28 +3,28 @@
 	"block.ba_bt.tab_icon": "BrassAmber Battletowers",
 
 	// Entità (Entities)
-	"entity.ba_bt.land_golem": "Golem della landa",
-	"entity.ba_bt.ocean_golem": "Golem d'oceano",
-	"entity.ba_bt.core_golem": "Golem principale",
-	"entity.ba_bt.nether_golem": "Golem del Nether",
-	"entity.ba_bt.end_golem": "Golem dell'End",
-	"entity.ba_bt.sky_golem": "Golem del cielo",
+	"entity.ba_bt.land_golem": "Bahrynz'muul, L'Antico osservatore",
+	"entity.ba_bt.ocean_golem": "Moraizu'un, Signore delle profondità",
+	"entity.ba_bt.core_golem": "Obthu'ryn, Dio del nucleo",
+	"entity.ba_bt.nether_golem": "Vraag'iidra, Incarnazione dell'ira",
+	"entity.ba_bt.end_golem": "Shul'losniir, Il Guardiano sfigurato",
+	"entity.ba_bt.sky_golem": "Veyhz'kriin, Dea dei cieli",
 
 
 	"entity.ba_bt.sky_minion": "Minion del cielo",
-	"entity.ba_bt.platinum_skeleton": "Scheletro di platino",
+	"entity.ba_bt.platinum_skeleton": "Cavaliere di platino",
 	"entity.ba_bt.bt_cultist": "Cultista",
 
 	"entity.ba_bt.land_monolith": "Monolite della landa",
 	"entity.ba_bt.ocean_monolith": "Monolite d'oceano",
-	"entity.ba_bt.core_monolith": "Monolite principale",
+	"entity.ba_bt.core_monolith": "Monolite del nucleo",
 	"entity.ba_bt.nether_monolith": "Monolite del Nether",
 	"entity.ba_bt.end_monolith": "Monolite dell'End",
 	"entity.ba_bt.sky_monolith": "Monolite del cielo",
 
 	"entity.ba_bt.land_obelisk": "Obelisco della landa",
 	"entity.ba_bt.ocean_obelisk": "Obelisco dell'oceano",
-	"entity.ba_bt.core_obelisk": "Obelisco principale",
+	"entity.ba_bt.core_obelisk": "Obelisco del nucleo",
 	"entity.ba_bt.nether_obelisk": "Obelisco del Nether",
 	"entity.ba_bt.end_obelisk": "Obelisco dell'End",
 	"entity.ba_bt.sky_obelisk": "Obelisco del cielo",
@@ -40,7 +40,7 @@
 	"ba_bt.subtitle.golem.special": "Attacco del Golem",
 	"ba_bt.subtitle.golem.fight": "Musica da boss del Golem",
 
-	"ba_bt.subtitle.monolith.spawn.golem": "Il Golem comincia ad apparire",
+	"ba_bt.subtitle.monolith.spawn.golem": "Il Golem sta per liberarsi!",
 
 	"ba_bt.subtitle.tower.break.start": "La torre comincia a distruggersi",
 	"ba_bt.subtitle.tower.break.crumble": "La torre crolla",
@@ -64,21 +64,21 @@
 	// Oggetti (Items)
 	"item.ba_bt.monolith_key_land": "Chiave del monolite della landa",
 	"item.ba_bt.monolith_key_ocean": "Chiave del monolite dell'oceano",
-	"item.ba_bt.monolith_key_core": "Chiave del monolite principale",
+	"item.ba_bt.monolith_key_core": "Chiave del monolite del nucleo",
 	"item.ba_bt.monolith_key_nether": "Chiave del monolite del Nether",
 	"item.ba_bt.monolith_key_end": "Chiave del monolite dell'End",
 	"item.ba_bt.monolith_key_sky": "Chiave del monolite del cielo",
 
 	"item.ba_bt.guardian_eye_land": "Occhio del guardiano della landa",
 	"item.ba_bt.guardian_eye_ocean": "Occhio del guardiano dell'oceano",
-	"item.ba_bt.guardian_eye_core": "Occhio del guardiano principale",
+	"item.ba_bt.guardian_eye_core": "Occhio del guardiano del nucleo",
 	"item.ba_bt.guardian_eye_nether": "Occhio del guardiano del Nether",
-	"item.ba_bt.guardian_eye_end": "Occhio del guardiano dell'End",
+	"item.ba_bt.guardian_eye_end": "Occhio del custode dell'End",
 	"item.ba_bt.guardian_eye_sky": "Occhio del guardiano del cielo",
 
 	"item.ba_bt.monolith_land": "Monolite della landa",
 	"item.ba_bt.monolith_ocean": "Monolite d'oceano",
-	"item.ba_bt.monolith_core": "Monolite principale",
+	"item.ba_bt.monolith_core": "Monolite del nucleo",
 	"item.ba_bt.monolith_nether": "Monolite del Nether",
 	"item.ba_bt.monolith_end": "Monolite dell'End",
 	"item.ba_bt.monolith_sky": "Monolite del cielo",
@@ -94,24 +94,24 @@
 
 	"item.ba_bt.land_chest_shard": "Frammento baule della landa",
 
-	"item.ba_bt.platinum_skeleton_spawn_egg": "Uovo generatore dello scheletro di platino",
+	"item.ba_bt.platinum_skeleton_spawn_egg": "Uovo generatore del cavaliere di platino",
 
 	// Sottotitoli degli oggetti (Item Tooltips)
 	"tooltip.ba_bt.hold_shift": "Tieni premuto Maiusc per maggiori informazioni.",
-	"tooltip.ba_bt.monolith": "Il Monolite serve ad evocare un Golem della battaglia.",
-	"tooltip.ba_bt.monolith_key": "Posiziona 3 chiavi in un monolite per evocare un Golem Guadiano."
-	"tooltip.ba_bt.tower_chest": "Distruggi tutti gli spawner su questo piano della torre per sbloccare. Può essere piazzata \"sbloccata\" in modalità sopravvivenza.",
-	"tooltip.ba_bt.golem_chest": "Sconfiggi il Golem per sbloccare",
+	"tooltip.ba_bt.monolith": "Il guardiano sembra intrappolato all'interno!",
+	"tooltip.ba_bt.monolith_key": "Confido tu sappia a cosa vai incontro...",
+	"tooltip.ba_bt.tower_chest": "Si sblocca quando tutti i generatori del piano vengono distrutti",
+	"tooltip.ba_bt.golem_chest": "E' legata all'energia vitale del guardiano, non si aprirà!",
 
 	// Scritte in sovraimpressione (Overscreen titles)
-	"title.ba_bt.guardian_defeated_1": "Il Guardiano è caduto.",
+	"title.ba_bt.guardian_defeated_1": " è caduto.",
 	"title.ba_bt.guardian_defeated_2": "Senza la sua energia...",
-	"title.ba_bt.guardian_defeated_3": "...la torrè crollerà...",
+	"title.ba_bt.guardian_defeated_3": "...la torrè crollerà!",
 
-	"title.ba_bt.land": "Terra",
-	"title.ba_bt.ocean": "Oceano",
-	"title.ba_bt.core": "Principale",
-	"title.ba_bt.nether": "Nether",
-	"title.ba_bt.end": "End",
-	"title.ba_bt.sky": "Cielo"
+	"title.ba_bt.land": "Bahrynz'muul, Guardiano della landa",
+	"title.ba_bt.ocean": "Moraizu'un, Guardiano dell'oceano",
+	"title.ba_bt.core": "Obthu'ryn, Dio del Nucleo",
+	"title.ba_bt.nether": "Vraag'iidra, Tiranno del Nether",
+	"title.ba_bt.end": "Shul'losniir, Custode dell'End",
+	"title.ba_bt.sky": "Veyhz'kriin, Dea del cielo"
 }

--- a/src/main/resources/assets/ba_bt/lang/it_it.json
+++ b/src/main/resources/assets/ba_bt/lang/it_it.json
@@ -3,28 +3,28 @@
 	"block.ba_bt.tab_icon": "BrassAmber Battletowers",
 
 	// Entità (Entities)
-	"entity.ba_bt.land_golem": "Golem della landa",
-	"entity.ba_bt.ocean_golem": "Golem d'oceano",
-	"entity.ba_bt.core_golem": "Golem principale",
-	"entity.ba_bt.nether_golem": "Golem del Nether",
-	"entity.ba_bt.end_golem": "Golem dell'End",
-	"entity.ba_bt.sky_golem": "Golem del cielo",
+	"entity.ba_bt.land_golem": "Bahrynz'muul, L'Antico osservatore",
+	"entity.ba_bt.ocean_golem": "Moraizu'un, Signore delle profondità",
+	"entity.ba_bt.core_golem": "Obthu'ryn, Dio del nucleo",
+	"entity.ba_bt.nether_golem": "Vraag'iidra, Incarnazione dell'ira",
+	"entity.ba_bt.end_golem": "Shul'losniir, Il Guardiano sfigurato",
+	"entity.ba_bt.sky_golem": "Veyhz'kriin, Dea dei cieli",
 
 
 	"entity.ba_bt.sky_minion": "Minion del cielo",
-	"entity.ba_bt.platinum_skeleton": "Scheletro di platino",
+	"entity.ba_bt.platinum_skeleton": "Cavaliere di platino",
 	"entity.ba_bt.bt_cultist": "Cultista",
 
 	"entity.ba_bt.land_monolith": "Monolite della landa",
 	"entity.ba_bt.ocean_monolith": "Monolite d'oceano",
-	"entity.ba_bt.core_monolith": "Monolite principale",
+	"entity.ba_bt.core_monolith": "Monolite del nucleo",
 	"entity.ba_bt.nether_monolith": "Monolite del Nether",
 	"entity.ba_bt.end_monolith": "Monolite dell'End",
 	"entity.ba_bt.sky_monolith": "Monolite del cielo",
 
 	"entity.ba_bt.land_obelisk": "Obelisco della landa",
 	"entity.ba_bt.ocean_obelisk": "Obelisco dell'oceano",
-	"entity.ba_bt.core_obelisk": "Obelisco principale",
+	"entity.ba_bt.core_obelisk": "Obelisco del nucleo",
 	"entity.ba_bt.nether_obelisk": "Obelisco del Nether",
 	"entity.ba_bt.end_obelisk": "Obelisco dell'End",
 	"entity.ba_bt.sky_obelisk": "Obelisco del cielo",
@@ -40,7 +40,7 @@
 	"ba_bt.subtitle.golem.special": "Attacco del Golem",
 	"ba_bt.subtitle.golem.fight": "Musica da boss del Golem",
 
-	"ba_bt.subtitle.monolith.spawn.golem": "Il Golem comincia ad apparire",
+	"ba_bt.subtitle.monolith.spawn.golem": "Il Golem sta per liberarsi!",
 
 	"ba_bt.subtitle.tower.break.start": "La torre comincia a distruggersi",
 	"ba_bt.subtitle.tower.break.crumble": "La torre crolla",
@@ -64,21 +64,21 @@
 	// Oggetti (Items)
 	"item.ba_bt.monolith_key_land": "Chiave del monolite della landa",
 	"item.ba_bt.monolith_key_ocean": "Chiave del monolite dell'oceano",
-	"item.ba_bt.monolith_key_core": "Chiave del monolite principale",
+	"item.ba_bt.monolith_key_core": "Chiave del monolite del nucleo",
 	"item.ba_bt.monolith_key_nether": "Chiave del monolite del Nether",
 	"item.ba_bt.monolith_key_end": "Chiave del monolite dell'End",
 	"item.ba_bt.monolith_key_sky": "Chiave del monolite del cielo",
 
 	"item.ba_bt.guardian_eye_land": "Occhio del guardiano della landa",
 	"item.ba_bt.guardian_eye_ocean": "Occhio del guardiano dell'oceano",
-	"item.ba_bt.guardian_eye_core": "Occhio del guardiano principale",
+	"item.ba_bt.guardian_eye_core": "Occhio del guardiano del nucleo",
 	"item.ba_bt.guardian_eye_nether": "Occhio del guardiano del Nether",
-	"item.ba_bt.guardian_eye_end": "Occhio del guardiano dell'End",
+	"item.ba_bt.guardian_eye_end": "Occhio del custode dell'End",
 	"item.ba_bt.guardian_eye_sky": "Occhio del guardiano del cielo",
 
 	"item.ba_bt.monolith_land": "Monolite della landa",
 	"item.ba_bt.monolith_ocean": "Monolite d'oceano",
-	"item.ba_bt.monolith_core": "Monolite principale",
+	"item.ba_bt.monolith_core": "Monolite del nucleo",
 	"item.ba_bt.monolith_nether": "Monolite del Nether",
 	"item.ba_bt.monolith_end": "Monolite dell'End",
 	"item.ba_bt.monolith_sky": "Monolite del cielo",
@@ -94,24 +94,24 @@
 
 	"item.ba_bt.land_chest_shard": "Frammento baule della landa",
 
-	"item.ba_bt.platinum_skeleton_spawn_egg": "Uovo generatore dello scheletro di platino",
+	"item.ba_bt.platinum_skeleton_spawn_egg": "Uovo generatore del cavaliere di platino",
 
 	// Sottotitoli degli oggetti (Item Tooltips)
 	"tooltip.ba_bt.hold_shift": "Tieni premuto Maiusc per maggiori informazioni.",
-	"tooltip.ba_bt.monolith": "Il Monolite serve ad evocare un Golem della battaglia.",
-	"tooltip.ba_bt.monolith_key": "Posiziona 3 chiavi in un monolite per evocare un Golem Guadiano.",
-	"tooltip.ba_bt.tower_chest": "Distruggi tutti gli spawner su questo piano della torre per sbloccare. Può essere piazzata \"sbloccata\" in modalità sopravvivenza.",
-	"tooltip.ba_bt.golem_chest": "Sconfiggi il Golem per sbloccare",
+	"tooltip.ba_bt.monolith": "Il guardiano sembra intrappolato all'interno!",
+	"tooltip.ba_bt.monolith_key": "Confido tu sappia a cosa vai incontro...",
+	"tooltip.ba_bt.tower_chest": "Si sblocca quando tutti i generatori del piano vengono distrutti",
+	"tooltip.ba_bt.golem_chest": "E' legata all'energia vitale del guardiano, non si aprirà!",
 
 	// Scritte in sovraimpressione (Overscreen titles)
-	"title.ba_bt.guardian_defeated_1": "Il Guardiano è caduto.",
+	"title.ba_bt.guardian_defeated_1": " è caduto.",
 	"title.ba_bt.guardian_defeated_2": "Senza la sua energia...",
-	"title.ba_bt.guardian_defeated_3": "...la torrè crollerà...",
+	"title.ba_bt.guardian_defeated_3": "...la torrè crollerà!",
 
-	"title.ba_bt.land": "Terra",
-	"title.ba_bt.ocean": "Oceano",
-	"title.ba_bt.core": "Principale",
-	"title.ba_bt.nether": "Nether",
-	"title.ba_bt.end": "End",
-	"title.ba_bt.sky": "Cielo"
+	"title.ba_bt.land": "Bahrynz'muul, Guardiano della landa",
+	"title.ba_bt.ocean": "Moraizu'un, Guardiano dell'oceano",
+	"title.ba_bt.core": "Obthu'ryn, Dio del Nucleo",
+	"title.ba_bt.nether": "Vraag'iidra, Tiranno del Nether",
+	"title.ba_bt.end": "Shul'losniir, Custode dell'End",
+	"title.ba_bt.sky": "Veyhz'kriin, Dea del cielo"
 }


### PR DESCRIPTION
Updated italian translations as requested in translation issue (#57) and added more context to some other lines that are not affected from changes in the original EN file. More details in the update it_it.json commit description, I also quote that there for convenience.

>Changed line translation - no new lines.
>
>**it_it, it_ch**
>_Lines Changed:_
>
> - 6-11 ~ Updated translations for new names, keeping original Name and translated only the title;
> - 15, 97 ~ Updated translation to knigth, no more skeletons in this lines;
> - 20, 27, 67, 74, 81 ~ Changed "principale" to "nucleo" to better adapt the new context of the Guardian of the core in the italian language;
> - 43 ~ Updated the line to have more impact from "Golem Begins Spawning" to "The Golem is about to break free!" also for people that use subtitle (i translated to en the changes i made in it to better unterstanding, translation is a bit literal in this case)
> - 101-104 ~ Updated translation from new sentences in EN file;
> - 107 ~ Removed "Guardiano" because is also missing in the EN file;
> - 109 ~ Changed "..." to "!" at the end of the sentence to add more pathos (https://en.wikipedia.org/wiki/Pathos);
> - 111-116 ~ Updated translations, at 115 line i used "Custode" (Gatekeeper) instead of "Guardiano" because sounds more ancient in italian and i feel is more appropriate in this context.

